### PR TITLE
remove duplicate code in neighbours methods

### DIFF
--- a/intense/qc.py
+++ b/intense/qc.py
@@ -1118,15 +1118,14 @@ class Qc:
 
         """
         df = self.gauge.data.to_frame("target")
-        
+
         # convert hourly to daily 7am-7am
-        df["roll"] = np.around(df.target.rolling(window=24, center=False, min_periods=24).sum(), 1)
-        df_daily = df[df.index.hour == 7]
-        daily_values = pd.Series(df_daily.roll.values, index=(df_daily.index.to_series() - timedelta(days=1)).dt.date)
+        daily_values = df.target.resample('24H', base=7, closed='right').sum(min_count=24).round(1)
+        daily_values.index = daily_values.index.date
 
         # offset by one day in either direction to help identify optimum offset
-        daily_values_lag_minus1 = pd.Series(df_daily.roll.values, index=(df_daily.index.to_series() - timedelta(days=2)).dt.date)
-        daily_values_lag_plus1 = pd.Series(df_daily.roll.values, index=df_daily.index.to_series().dt.date)
+        daily_values_lag_minus1 = pd.Series(daily_values.values, index=daily_values.index - timedelta(days=1))
+        daily_values_lag_plus1 = pd.Series(daily_values.values, index=daily_values.index + timedelta(days=1))
 
         neighbours = self.find_daily_neighbours()
 
@@ -1215,6 +1214,7 @@ class Qc:
         df = self.gauge.data.to_frame("target")
 
         # convert hourly to daily 7am-7am
+        # groups including missing data are dropped by using np.array.sum
         dfm = df.resample("M", label='right', closed='right').apply(lambda x: x.values.sum())
         # find neighbours
         neighbours = self.find_monthly_neighbours()

--- a/intense/qc.py
+++ b/intense/qc.py
@@ -1054,10 +1054,8 @@ class Qc:
         df = self.gauge.data.to_frame("target")
 
         # convert hourly to daily 7am-7am
-        df["roll"] = np.around(df.target.rolling(window=24, center=False, min_periods=24).sum(), 1)
-        df_daily = df[df.index.hour == 7]
-
-        daily_values = pd.Series(df_daily.roll.values, index=(df_daily.index.to_series() - timedelta(days=1)).dt.date)
+        daily_values = df.target.resample('24H', base=7, closed='right').sum(min_count=24).round(1)
+        daily_values.index = daily_values.index.date
 
         neighbours, paths = self.find_hourly_neighbours()
 

--- a/tests/sample_data/Flags/DE_02483_QC_hourly_daily_monthly.txt
+++ b/tests/sample_data/Flags/DE_02483_QC_hourly_daily_monthly.txt
@@ -33,8 +33,8 @@ PRCPTOT checks: [4, 4, 3, 4, 2]
 Years where min value changes: (1, [2006, 2010])
 Optimum offset: 0
 Pre QC Affinity Index: 0.9597
-Pre QC Pearson coefficient: 0.01467
-Factor against nearest daily gauge: 2.47159
+Pre QC Pearson coefficient: 0.01466
+Factor against nearest daily gauge: 2.46822
 0.9, -999, -999, -999, -999, -999, 0, 0, -999, 0, 0, 0, 0, 3
 0.3, -999, -999, -999, -999, -999, 0, 0, -999, 0, 0, 0, 0, 3
 0.3, -999, -999, -999, -999, -999, 0, 0, -999, 0, 0, 0, 0, 3


### PR DESCRIPTION
Closes #28 

## Major changes
- find_hourly_neighbours, find_daily_neighbours and find_monthly_neighbours have been combined into find_neighbours
- new utils.propagate_flags function

# Other changes
- check_hourly_neighbours and check_daily_neighbours now use resample instead of rolling sum